### PR TITLE
Update language attribute in default.html

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-Hans">
 <head>
   <meta charset="utf-8">
   <title>{% if page.title %}{{page.title}}{% else %}{{ site.title | escape }}{% endif %}</title>


### PR DESCRIPTION
So that the browser font fallback works properly.

Before:
<img width="1215" alt="Screen Shot 2022-10-24 at 01 35 48" src="https://user-images.githubusercontent.com/57782783/197483857-12591a5c-2d9d-4073-b5e5-d267c9ae3bd2.png">
After:
<img width="1281" alt="Screen Shot 2022-10-24 at 01 36 27" src="https://user-images.githubusercontent.com/57782783/197483988-e3cc801c-95a5-4bf2-974b-b756c03ac34e.png">
