### PR TITLE
Update homepage to new design.

### DIFF
--- a/_data/data-sponsor.yml
+++ b/_data/data-sponsor.yml
@@ -11,10 +11,20 @@
 # These fields are referenced in sponsor-template.html.
 
 sponsor-home:
-  sponsor-heading: 2022 歌手赛赞助商
   sponsor-levels:
-    - level-name: platinum
-      level-heading: <br>钻石赞助 虚位以待<br><br>
+    - level-name: sponsor
+      level-heading: 主要赞助商
+      elements-div-style-class: col-6 col-lg-4 mb-1
+      sponsor-elements:
+      - name: Ivy Zhang & Anna Duan Realty Team
+        description: Ivy Zhang & Anna Duan 团队是Coldwell Banker全职资深Top地产经纪团队，是Top Agent Network的成员，交易过上百套房屋买卖，得到客户们Zillow 和Google 全五星好评，团队资源丰富，能在房屋买卖，贷款，投资，装修，出租，设计等方面提供给客户们全方位的服务和咨询。永远将客户的利益放在首位，根据客户的具体情况，需求和预算，帮助客人制定专属地产投资规划。
+        image: https://res.cloudinary.com/zaigezaigu/image/upload/v1670308954/zgzg-io-website/%E8%B5%9E%E5%8A%A9/Ivy_Zhang_and_Anna_Duan_Realty_Team_s3t45u.png
+      - name: Lusso Inc - Tile, Hardwook, Kitchen & Bath
+        image: https://res.cloudinary.com/zaigezaigu/image/upload/v1670309781/zgzg-io-website/%E8%B5%9E%E5%8A%A9/lusso_logo_daqkws.jpg
+        description: What makes design so alluring? We believes the answer is designers. That’s why we have made our entire focus on you – the designer. Your style, your ideas, your creativity. Go on – Try, share and design now!
+      - name: Enjoy Dance Studio
+        image: https://res.cloudinary.com/zaigezaigu/image/upload/v1670310255/zgzg-io-website/%E8%B5%9E%E5%8A%A9/EDS_Logo_black_mnrrkn.png
+        description: EDS 是湾区最大的华人舞蹈工作室。We have 街舞 HIPHOP | 韩舞 K-POP | 爵士 JAZZ | 机械舞 POPPING | 现代舞 CONTEMPORARY ｜ 编舞 CHOREO。9 locations across the bay area!
 
 sponsors-yj-2022:
   sponsor-heading: 2022 云集赞助商

--- a/_data/data.yml
+++ b/_data/data.yml
@@ -71,9 +71,6 @@ friends:
     description: 一个对话、分享的平台。尽可能地满足我们对这个世界不该磨灭的好奇心。
 
 programmes:
-  - name: 体娱风云
-    image: https://tva1.sinaimg.cn/large/008i3skNgy1gty85ki0y8j60sc0scdj902.jpg
-    description: 我们组织羽毛球、桌游、趣味运动会、聚餐……
   - name: 职挂云帆
     image: https://tva1.sinaimg.cn/large/008i3skNgy1gt4hqf0i8ij30i00i0wg2.jpg
     description: 规划职业生涯，提升职业技能，了解不同行业，收获创业灵感。
@@ -87,17 +84,22 @@ programmes:
   - name: 书影婆娑
     image: https://tva1.sinaimg.cn/large/008i3skNgy1gumieg96wqj60lw0lwmyt02.jpg
     description: 我们组织多种书籍电影类文化活动：线下分享会、客厅沙龙、好书共读、P2P图书馆、朗读会、电影马拉松……
+    button-url: https://mp.weixin.qq.com/s/Llop7DVDmyHwg_Jycv5w3A
+    button-text: 了解更多
+  - name: 体娱风云
+    image: https://tva1.sinaimg.cn/large/008i3skNgy1gty85ki0y8j60sc0scdj902.jpg
+    description: 我们组织羽毛球、桌游、趣味运动会、聚餐……
 
 programmes_chunwan:
-  - name: 歌手赛
-    image: https://res.cloudinary.com/zaigezaigu/image/upload/t_auto_eco_compression/v1655097027/singer_osizeh.png
-    description: 2022 "载歌在谷" 歌手赛，我们在成功的经验上进一步扩大规模，全新规划，为您打造一年一度的，高水准的华人歌手赛。
-    button-url: /singer/
-    button-text: 详情
   - name: 春节晚会
     image: https://res.cloudinary.com/zaigezaigu/image/upload/t_auto_eco_compression/v1638942437/zgzg-io-website/WechatIMG869_k2uxam.jpg
     description: 承袭自2015年Google春晚，现面向整个湾区。由200余名主要来自湾区高科技公司的志愿者和演员耗时半年精心打造，是湾区规模最大，观众最多，最具硅谷特色的春节晚会。
     button-url: /gala/
+    button-text: 详情
+  - name: 歌手赛
+    image: https://res.cloudinary.com/zaigezaigu/image/upload/t_auto_eco_compression/v1655097027/singer_osizeh.png
+    description: 2022 "载歌在谷" 歌手赛，我们在成功的经验上进一步扩大规模，全新规划，为您打造一年一度的，高水准的华人歌手赛。
+    button-url: /singer/
     button-text: 详情
   - name: 游园会
     image: https://res.cloudinary.com/zaigezaigu/image/upload/t_auto_eco_compression/v1638942438/zgzg-io-website/WechatIMG870_vnlf8i.jpg

--- a/_includes/large-card.html
+++ b/_includes/large-card.html
@@ -1,4 +1,4 @@
-<div class="col-12 col-md-6 col-lg-4 mb-5">
+<div class="col-12 col-md-6 col-lg-6 mb-5">
   <div class="card-custom large-card">
     {% if programme.image %}
       <div class="card-image large-card-image"><img alt="{{ programme.name }}" src="{{ programme.image }}" /></div>

--- a/_includes/programmes.html
+++ b/_includes/programmes.html
@@ -4,29 +4,42 @@
       {% include large-card.html %}
     {% endfor %}
   {% endif %}
-  <a href="mailto:contact-us@zgzg.io" id="join">
-    <div class="col-12 col-md-6 col-lg-4 mb-5">
-      <div class="programme">
-          <div class="programme-image">
-            +
+
+  {% if show_join_us == true %}
+    <a href="mailto:contact-us@zgzg.io" id="join">
+      <div class="col-12 col-md-6 col-lg-4 mb-5">
+        <div class="programme">
+            <div class="programme-image">
+              +
+            </div>
+          <h2 class="programme-title">加入我们</h2>
+          <div class="programme-content">
+            <p class="programme-description">加入我们社区，孵化你的兴趣小组；或者，帮助已有栏目办得更好！</p>
           </div>
-        <h2 class="programme-title">加入我们</h2>
-        <div class="programme-content">
-          <p class="programme-description">加入我们社区，孵化你的兴趣小组；或者，帮助已有栏目办得更好！</p>
         </div>
       </div>
-    </div>
-  </a>
+    </a>
+  {% endif %}
 </div>
-<p>新志愿者？请参阅<a href="https://zgzg.link/onboard">《新人大礼包》</a>。</p>
-<h2>已完结栏目</h2>
-{% if show_concluded_programmes == true %}
-  <p>完成了历史使命，也值得拥有姓名！</p>
-  <div class="row" id="concluded-programmes">
-    {% for programme in site.data.data.past-programmes %}
-      {% include programme.html %}
-    {% endfor %}
-  </div>
+
+{% if show_join_us == true %}
+  <p>新志愿者？请参阅<a href="https://zgzg.link/onboard">《新人大礼包》</a>。</p>
+  <h2>已完结栏目</h2>
+  {% if show_concluded_programmes == true %}
+    <p>完成了历史使命，也值得拥有姓名！</p>
+    <div class="row" id="concluded-programmes">
+      {% for programme in site.data.data.past-programmes %}
+        {% include programme.html %}
+      {% endfor %}
+    </div>
+  {% else %}
+    <p>请参见<a href="/yj/">云集专页</a>。</p>
+  {% endif %}
+
 {% else %}
-  <p>请参见<a href="/yj/">云集专页</a>。</p>
+
+  <a href="/yj/">
+    <button type="button" class="btn btn-primary btn-lg" id="more-programmes">更多 “云集”</button>
+  </a>
+
 {% endif %}

--- a/_includes/sponsor-template.html
+++ b/_includes/sponsor-template.html
@@ -1,4 +1,4 @@
-<div id="gala-sponsors" class="strip container">
+<div id="gala-sponsors" class="container">
     <!-- sponsor heading, such as 2022 歌手赛赞助商 -->
     {% if sponsor_type.sponsor-heading %}
         <div class="row">
@@ -11,9 +11,15 @@
     <!-- sponsors by level, such as 白金赞助 -->
     {% for sponsor_level in sponsor_type.sponsor-levels %}
     <div class="row">
-        <div class="col">
+        <div class="col home-section-header pb-small">
             <!-- sponsor level heading, such as the text 白金赞助 or 虚位以待 -->
             <h2 class="gala-heading">{{sponsor_level.level-heading}}</h2>
+            <div class="divider">
+                <hr></hr>
+            </div>
+            <div class="home-section-content">
+                <p class="py-2"><br></p>
+            </div>
         </div>
     </div>
     {% if sponsor_level.sponsor-elements %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -23,78 +23,87 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="container">
     <div class="row justify-content-start">
       <div class="col-12 col-md-7 col-lg-5 col-md-3 order-2 order-md-2" id="content">
-        <h1>2023兔年<br>“载歌在谷”春晚<br>赞助商招募火热进行中</h1>
+        <h2>2023兔年<br>“载歌在谷”春晚<br>赞助商招募火热进行中</h2>
         <p>
-            兔年春晚及游园时间：2023年1月21日 <br>
-            地点：San Jose Center for Performing Arts <br>
-            联系赞助组 Email: sponsor-gala@zgzg.io <br>
-            WeChat: “载歌在谷” <br>
-            招商类别与赞助商权益详情，请扫描二维码
+            <b>兔年春晚及游园时间：</b>2023年1月21日 <br>
+            <b>地点：</b>San Jose Center for Performing Arts <br>
+            <b>联系赞助组 Email: </b><u>sponsor-gala@zgzg.io</u> <br>
+            <b>WeChat公众号:</b> “载歌在谷” <br>
+            招商类别与赞助商权益详情，请访问以下链接
         </p>
-        <img src="https://tva1.sinaimg.cn/large/008vxvgGgy1h7qq9nha31j306y06z74o.jpg" alt="报名二维码" />
+        <a href="https://mp.weixin.qq.com/s/BzpzveTu9Uyzw9j3c1Nmpg">
+          <button type="button" class="btn btn-light btn-primary btn-lg">查看详情</button>
+        </a>
       </div>
     </div>
   </div>
 </div>
 
-<!-- Tab links -->
-<div class="tab">
-  <button class="tab-links default-open" onclick="openTab(event)" data-tab-group="main" data-tab-id="programmes_chunwan">载歌在谷精彩活动</button>
-  <button class="tab-links" onclick="openTab(event)" data-tab-group="main" data-tab-id="programmes">“云集”系列栏目</button>
-  <button class="tab-links" onclick="openTab(event)" data-tab-group="main" data-tab-id="sponsor">赞助商</button>
+<div class="strip">
+  <div class="container">
+
+      <div class="home-section-header pb-large">
+        <h2>关于 “载歌在谷”</h2>
+        <div class="divider">
+          <hr></hr>
+        </div>
+        <div class="home-section-content">
+          <p class="py-2">“载歌在谷”社区是一个以硅谷高科技华人从业者为主要贡献者的非盈利组织。“载歌在谷”社区旨在丰富硅谷华人的文化生活、弘扬中华文化。社区以文艺活动为主要载体，如“载歌在谷”春节晚会。</p>
+        </div>
+      </div>
+
+      {% if site.data.data.programmes_chunwan %}
+        {% for item in site.data.data.programmes_chunwan %}
+          {% assign remainder = forloop.index0 | modulo: 2 %}
+          {% if remainder == 0 %}
+            {% include list-item-left.html %}
+          {% else %}
+            {% include list-item-right.html %}
+          {% endif %}
+        {% endfor %}
+      {% endif %}
+  </div>
 </div>
 
-<!-- Tab content -->
-<div id="programmes_chunwan" class="tab-content">
-  <div class="strip">
-    <div class="container pt-6 pb-6 pt-md-6 pb-md-6">
-      <h1>载歌在谷精彩活动</h1>
-      <div class="row justify-content-start">
-        {% if site.data.data.programmes_chunwan %}
-          {% for item in site.data.data.programmes_chunwan %}
-            {% assign remainder = forloop.index0 | modulo: 2 %}
-            {% if remainder == 0 %}
-              {% include list-item-left.html %}
-            {% else %}
-              {% include list-item-right.html %}
-            {% endif %}
-          {% endfor %}
-        {% endif %}
+<div class="strip">
+  <div class="container pb-6 pb-md-6" id="yj">
+
+    <div class="home-section-header pb-small">
+      <h2>“云集”系列栏目</h2>
+      <div class="divider">
+        <hr></hr>
+      </div>
+      <div class="home-section-content">
+        <p class="py-2">载歌在谷社区孵化了许多群体，常年举办各种活动。快来参加吧！</p>
       </div>
     </div>
-  </div>
-</div>
 
-<div id="programmes" class="tab-content">
-  <div class="strip">
-    <div class="container pt-6 pb-6 pt-md-6 pb-md-6" id="yj">
-      <h1>“云集”系列栏目</h1>
-      <p>载歌在谷社区孵化了许多群体，常年举办各种活动。快来参加吧！</p>
-      {% assign show_concluded_programmes = false %}
-      {% include programmes.html %}
-    </div>
-  </div>
-</div>
-
-<div id="sponsor" class="tab-content">
-  <div class="strip">
-    <div class="container pt-6 pb-6 pt-md-6 pb-md-6" id="sponsors">
-      {% assign sponsor_type = site.data.data-sponsor.sponsor-home %}
-      {% include sponsor-template.html %}
-      {% assign sponsor_type = site.data.data-sponsor.sponsors-yj-2022 %}
-      {% include sponsor-template.html %}
-    </div>
+    {% assign show_concluded_programmes = false %}
+    {% assign show_join_us = false %}
+    {% include programmes.html %}
   </div>
 </div>
 
 <div class="strip strip-grey">
-  <div class="container pt-6 pb-6 pb-md-10" id="friends">
-    <div class="row">
+  <div class="container" id="sponsors">
+    {% assign sponsor_type = site.data.data-sponsor.sponsor-home %}
+    {% include sponsor-template.html %}
+  </div>
+</div>
+
+<div class="strip">
+  <div class="container" id="friends">
+    
+    <div class="home-section-header pb-small">
       <h2>伙伴社区</h2>
+      <div class="divider">
+        <hr></hr>
+      </div>
+      <div class="home-section-content">
+        <p class="py-2">湾区其他以华人为主的非盈利组织。</p>
+      </div>
     </div>
-    <div class="row">
-      <p>湾区其他以华人为主的非盈利组织。</p>
-    </div>
+
     <div class="row justify-content-start">
       {% for friend in site.data.data.friends %}
       <div class="col-12 col-md-2 mb-1 pl-3 pr-3">

--- a/_layouts/programmes.html
+++ b/_layouts/programmes.html
@@ -8,5 +8,6 @@ bodyClass: page-home
 </div>
 <div class="container pt-6 pb-6 pt-md-10 pb-md-10" id="yj">
   {% assign show_concluded_programmes = true %}
+  {% assign show_join_us = true %}
   {% include programmes.html %}
 </div>

--- a/_sass/components/_card.scss
+++ b/_sass/components/_card.scss
@@ -9,6 +9,7 @@
   top: 16px;
   align-items: flex-start;
   padding: 0px;
+  margin: auto;
   .card-image {
     display: flex;
     margin-bottom: 20px;

--- a/_sass/components/_intro.scss
+++ b/_sass/components/_intro.scss
@@ -41,11 +41,6 @@
   }
 }
 
-.intro-small {
-  padding-top: 100px;
-  padding-bottom: 30px;
-}
-
 .home-section-header {
   text-align: center;
   font-style: normal;

--- a/_sass/components/_intro.scss
+++ b/_sass/components/_intro.scss
@@ -9,54 +9,81 @@
   overflow: hidden;
   background-size: cover;
   background-position: center;
+
   @include media-breakpoint-up(md) {
     padding-top: 60px;
     padding-bottom: 40px;
   }
-  h1 {
-    font-size: 40px;
-    font-weight: bold;
-    line-height: 1.2;
-    @include media-breakpoint-up(md) {
-      font-size: 40px;
-    }
-    @include media-breakpoint-up(lg) {
-      font-size: 40px;
-    }
-    margin: 30px 10px 15px 0;
-  }
+
   h2 {
-    font-size: 1.2rem;
-    line-height: 1.4;
-    margin: 30px 0 15px 0;
     font-family: $font-family-base;
+    font-weight: 700;
+    font-size: 36px;
+    line-height: 54px;
+    margin-bottom: 12px;
   }
+
   p {
-    font-size: 1.2rem;
-    font-weight: light;
-    line-height: 1.5;
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 26px;
     color: $white;
-  }
-  a {
-    color: $white-offset;
-    font: caption;
-  }
-  .button {
-  background: #fff;
-  color: #ec464f;
+    letter-spacing: 0.01em;
   }
 
   #content {
-    padding: 45px;
+    width: 482px;
+    height: 482px;
+    padding: 56px;
     background: $primary;
-
-    img {
-      width: 150px;
-    }
+    margin-left: auto;
+    margin-right: 32px;
   }
 }
 
 .intro-small {
   padding-top: 100px;
   padding-bottom: 30px;
+}
+
+.home-section-header {
+  text-align: center;
+  font-style: normal;
+  font-size: 20px;
+
+  h2 {
+    font-weight: 700;
+    font-size: 36px;
+  }
+
+  .divider {
+    width: 80px;
+    margin: auto;
+  }
+
+  hr {
+    width: 80px;
+    height: 4px;
+    margin: auto;
+    background-color: $primary;
+    opacity: 1;
+  }
+
+  p{
+    color: $black;
+  }
+
+  .home-section-content {
+    margin: auto;
+    width: 60%;
+  }
+}
+
+.pb-large {
+  margin-top: 120px;
+  margin-bottom: 120px;
+}
+
+.pb-small {
+  margin-top: 120px;
 }

--- a/_sass/components/_intro.scss
+++ b/_sass/components/_intro.scss
@@ -64,7 +64,7 @@
     opacity: 1;
   }
 
-  p{
+  p {
     color: $black;
   }
 

--- a/_sass/components/_programme.scss
+++ b/_sass/components/_programme.scss
@@ -54,3 +54,8 @@
     color: #888;
   }
 }
+
+#more-programmes {
+  display: flex; 
+  margin: 20px auto 20px auto;
+}

--- a/_sass/components/_programme.scss
+++ b/_sass/components/_programme.scss
@@ -56,6 +56,6 @@
 }
 
 #more-programmes {
-  display: flex; 
+  display: flex;
   margin: 20px auto 20px auto;
 }

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -398,6 +398,7 @@ h2.gala-heading {
 .sponsor img {
   width:90%;
   max-height: 400px;
+  object-fit: contain;
 }
 
 .rainbow-letters {


### PR DESCRIPTION
Updated homepage to new design:
<img width="1601" alt="image" src="https://user-images.githubusercontent.com/5152856/205868401-257aff1c-56dd-4047-a6f1-8311781b2db7.png">
<img width="1571" alt="image" src="https://user-images.githubusercontent.com/5152856/205868454-c9eb97e5-5e40-45b5-b8b9-941aa72fa582.png">
<img width="1562" alt="image" src="https://user-images.githubusercontent.com/5152856/205868524-9ea4b6ce-e151-4239-8a8f-ae85f3a7c381.png">

Related updates:
- Data:
  - New sponsor data for homepage.
  - Rearranged programmes data for better ordering.
- Sponsor template:
  - Uses underlined title style for all sponsor templates (can be reused in other sponsor pages).
  - Sponsor image uses "object-fit: contain" so that rectangular images will fit into a square with the original aspect ratio.
  - Removed the extraneous strip class that interferes with the background color.
- Programmes template:
  - Large card now defaults to 50% width (col-lg-6). This will change the /yj/ page, but doesn't impact the aesthetics. And the design will be changed in the future to use lists anyway.
  - Added the button to show more yj programmes to the template.